### PR TITLE
Delays won't occur if the file already exists

### DIFF
--- a/tidal_dl_ng/download.py
+++ b/tidal_dl_ng/download.py
@@ -271,7 +271,7 @@ class Download:
             items = list_media.items(limit=100)
             list_media_name = list_media.name[:30]
         else:
-            items = list_media.tracks(limit=999)
+            items = list_media.tracks(limit=9999)
             list_media_name = list_media.name[:30]
 
         if progress_gui is None:
@@ -285,7 +285,7 @@ class Download:
             for media in items:
                 Progress()
                 # TODO: Handle return value of `track` method.
-                self.item(
+                skip, full_path = self.item(
                     path_base=path_file,
                     file_template=file_name_relative,
                     media=media,
@@ -298,7 +298,7 @@ class Download:
                 if not progress_stdout:
                     progress_gui.list_item.emit(progress.tasks[p_task1].percentage)
 
-                if download_delay:
+                if download_delay and skip:
                     time_sleep: float = round(random.SystemRandom().uniform(2, 5), 1)
 
                     # TODO: Fix logging. Is not displayed in debug window.


### PR DESCRIPTION
Small tweaks to skip delays if a bunch of files are already downloaded.
