### PR TITLE
feat: allow downloading favorite tracks, artists, albums, and videos collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $ tidal-dl-ng --help
 │        for this option. To set a value for an option simply pass the value   │
 │        as the second argument                                                │
 │ dl                                                                           │
+│ dl_fav  Download from a favorites collection.                                │
 │ gui                                                                          │
 │ login                                                                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -48,12 +49,23 @@ pip install --upgrade tidal-dl-ng
 pip install --upgrade tidal-dl-ng[gui]
 ```
 
-You can use the command line (CLI) version to download media:
+## ⌨️ Usage
+
+You can use the command line (CLI) version to download media by URL:
 
 ```bash
 tidal-dl-ng dl https://tidal.com/browse/track/46755209
 # OR
 tdn dl https://tidal.com/browse/track/46755209
+```
+
+Or by your favorites collections:
+
+```bash
+tidal-dl-ng dl_fav tracks
+tidal-dl-ng dl_fav artists
+tidal-dl-ng dl_fav albums
+tidal-dl-ng dl_fav videos
 ```
 
 But also the GUI:
@@ -71,7 +83,7 @@ If you like to have the GUI version only as a binary, have a look at the
 
 ## 🧁 Features
 
-- Download Tracks, Videos, Albums, Playlists etc.
+- Download Tracks, Videos, Albums, Playlists, Favorite Tracks/Artists/Albums/Videos, etc.
 - Multithreaded and multi-chunked downloads
 - Metadata for songs
 - Adjustable audio and video download quality.

--- a/tidal_dl_ng/cli.py
+++ b/tidal_dl_ng/cli.py
@@ -23,6 +23,12 @@ from tidal_dl_ng.helper.wrapper import LoggerWrapped
 from tidal_dl_ng.model.cfg import HelpSettings
 
 app = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]}, add_completion=False)
+dl_fav_group = typer.Typer(
+    context_settings={"help_option_names": ["-h", "--help"]},
+    add_completion=True,
+    help="Download from a favorites collection.",
+)
+app.add_typer(dl_fav_group, name="dl_fav")
 
 
 def version_callback(value: bool):

--- a/tidal_dl_ng/cli.py
+++ b/tidal_dl_ng/cli.py
@@ -240,6 +240,58 @@ def download(
     return _download(ctx, urls)
 
 
+@dl_fav_group.command(
+    name="tracks",
+    help="Download your saved, favorite tracks collection.",
+)
+def download_fav_tracks(ctx: typer.Context):
+    # Call login method to validate the token.
+    ctx.invoke(login, ctx)
+
+    # Get favorite tracks
+    track_urls = [track.share_url for track in ctx.obj[CTX_TIDAL].session.user.favorites.tracks()]
+    return _download(ctx, track_urls, try_login=False)
+
+
+@dl_fav_group.command(
+    name="artists",
+    help="Download your saved, favorite artists collection.",
+)
+def download_fav_artists(ctx: typer.Context):
+    # Call login method to validate the token.
+    ctx.invoke(login, ctx)
+
+    # Get favorite artists
+    artist_urls = [artist.share_url for artist in ctx.obj[CTX_TIDAL].session.user.favorites.artists()]
+    return _download(ctx, artist_urls, try_login=False)
+
+
+@dl_fav_group.command(
+    name="albums",
+    help="Download your saved, favorite albums collection.",
+)
+def download_fav_albums(ctx: typer.Context):
+    # Call login method to validate the token.
+    ctx.invoke(login, ctx)
+
+    # Get favorite artists
+    artist_urls = [artist.share_url for artist in ctx.obj[CTX_TIDAL].session.user.favorites.albums()]
+    return _download(ctx, artist_urls, try_login=False)
+
+
+@dl_fav_group.command(
+    name="videos",
+    help="Download your saved, favorite videos collection.",
+)
+def download_fav_videos(ctx: typer.Context):
+    # Call login method to validate the token.
+    ctx.invoke(login, ctx)
+
+    # Get favorite artists
+    artist_urls = [artist.share_url for artist in ctx.obj[CTX_TIDAL].session.user.favorites.videos()]
+    return _download(ctx, artist_urls, try_login=False)
+
+
 @app.command()
 def gui(ctx: typer.Context):
     from tidal_dl_ng.gui import gui_activate


### PR DESCRIPTION
- Extract download logic to helper function.
- Adds the `dl_fav` command to be a command group and adds new subcommands:
    - `dl_fav tracks` - Download favorite tracks
    - `dl_fav artists` - Favorite artists
    - `dl_fav albums` - Favorite albums
    - `dl_fav videos` - Favorite videos
- Updates README to reflect new changes. 

![image](https://github.com/user-attachments/assets/3d77dbc8-de64-4004-8f82-ed4799bbf496)
