### PR TITLE
Update mkdocs.yml to include `home_page`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: tidal-dl-ng
 repo_url: https://github.com/exislow/tidal-dl-ng
 site_url: https://exislow.github.io/tidal-dl-ng
+home_page: https://exislow.github.io/tidal-dl-ng
 site_description: TIDAL Medial Downloader Next Generation!
 site_author: Robert Honz
 edit_uri: edit/main/docs/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: tidal-dl-ng
 repo_url: https://github.com/exislow/tidal-dl-ng
 site_url: https://exislow.github.io/tidal-dl-ng
-home_page: https://exislow.github.io/tidal-dl-ng
+home_page: https://github.com/exislow/tidal-dl-ng
 site_description: TIDAL Medial Downloader Next Generation!
 site_author: Robert Honz
 edit_uri: edit/main/docs/


### PR DESCRIPTION
Currently, installing via `pip` shows the following error every time on startup:

![image](https://github.com/user-attachments/assets/0dd3ea07-b4c5-496a-9031-8e2b21a733c9)

Going from this snippet of code, it appears to be due to the "Home-Page" value missing from the PyPi metadata.

https://github.com/exislow/tidal-dl-ng/blob/b0bf71ccf523359333c6a4eabfa973135832bd7e/tidal_dl_ng/__init__.py#L32-L41

This PR attempts to include it by adding the `home_page` value to the mkdocs file. I'll mention, I've not had too much experienc ein Python, but from rooting around in the project this `should` include the Homepage value within the package metadata.

After manually adding the Home Page value to the METADATA of the installed pip script, the update check no longer displays every startup, and manually checking for updates seems to work.

```
Metadata-Version: 2.3
Name: tidal-dl-ng
Version: 0.24.6
Summary: TIDAL Medial Downloader Next Generation!
Home-Page: https://github.com/exislow/tidal-dl-ng
// extra stuff
```

When checking for upates:

![image](https://github.com/user-attachments/assets/ccceea92-9ef0-4c04-a225-46e3cb7a643a)
