### PR TITLE
Fix path_playlist sanitization for leading slash

### DIFF
--- a/tidal_dl_ng/download.py
+++ b/tidal_dl_ng/download.py
@@ -745,7 +745,7 @@ class Download:
         # For each dir, which contains tracks
         for dir_scoped in dirs_scoped:
             # Sanitize final playlist name to fit into OS boundaries.
-            path_playlist = dir_scoped / (PLAYLIST_PREFIX + name_list + PLAYLIST_EXTENSION)
+            path_playlist = dir_scoped / (PLAYLIST_PREFIX + name_list.replace("/", "") + PLAYLIST_EXTENSION)
             path_playlist = pathlib.Path(path_file_sanitize(path_playlist, adapt=True))
 
             self.fn_logger.debug(f"Playlist: Creating {path_playlist}")


### PR DESCRIPTION
Path sanitization is lacking for leading slashes in m3u file names. This issue causes the program to crash with a “file not found” error if an album with a slash in its name is found (for instance, https://tidal.com/browse/album/17793566, where the slash is located in “KM **/** H”).

This commit addresses this issue by removing slash.