### PR TITLE
Fix UnboundLocalError in GUI on_populate_tree_lists method leading to unresponsive left panel

### DIFF
--- a/tidal_dl_ng/gui.py
+++ b/tidal_dl_ng/gui.py
@@ -360,6 +360,8 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
                 twi_child = QtWidgets.QTreeWidgetItem(twi_mixes)
                 name: str = item.title
                 info: str = item.sub_title
+            else:
+                continue
 
             twi_child.setText(0, name)
             set_user_list_media(twi_child, item)


### PR DESCRIPTION
### Summary
This pull request fixes a bug in the `on_populate_tree_lists` method where the left panel could become unresponsive when processing unexpected item types in user lists.

### Details
The issue occurred when an item in the `user_lists` did not match the expected types (`UserPlaylist`, `Playlist`, or `Mix`). This left the `twi_child` variable uninitialized, causing the following error:

```
> tidal-dl-ng-gui
Login successful. Have fun!
All setup.
Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/tidal_dl_ng/gui.py", line 364, in on_populate_tree_lists
    twi_child.setText(0, name)
    ^^^^^^^^^
UnboundLocalError: cannot access local variable 'twi_child' where it is not associated with a value
```

While the application itself did not crash, the left panel became unresponsive.

### Fix
Added an `else: continue` clause to ensure unsupported items are skipped, preventing the `twi_child` variable from being accessed without initialization.

### Testing
Tested with various user list combinations, including unsupported item types, to confirm that the left panel now loads correctly without issues.

---

If you have additional test cases or encounter related issues, feel free to provide feedback. Thanks for reviewing this PR!