### PR TITLE
feat: add metadata_write_url setting for conditional URL metadata wri…

### DIFF
--- a/tidal_dl_ng/download.py
+++ b/tidal_dl_ng/download.py
@@ -1213,7 +1213,7 @@ class Download:
             album_peak_amplitude=media_stream.album_peak_amplitude,
             track_replay_gain=media_stream.track_replay_gain,
             track_peak_amplitude=media_stream.track_peak_amplitude,
-            url_share=track.share_url if track.share_url else "",
+            url_share=track.share_url if track.share_url and self.settings.data.metadata_write_url else "",
             replay_gain_write=self.settings.data.metadata_replay_gain,
             upc=track.album.upc if track.album and track.album.upc else "",
         )

--- a/tidal_dl_ng/model/cfg.py
+++ b/tidal_dl_ng/model/cfg.py
@@ -45,6 +45,7 @@ class Settings:
     symlink_to_track: bool = False
     playlist_create: bool = False
     metadata_replay_gain: bool = True
+    metadata_write_url: bool = True
 
 
 @dataclass_json
@@ -99,6 +100,7 @@ class HelpSettings:
     )
     playlist_create: str = "Creates a '_playlist.m3u8' file for downloaded albums, playlists and mixes."
     metadata_replay_gain: str = "Replay gain information will be written to metadata."
+    metadata_write_url: str = "URL of the media file will be written to metadata."
 
 
 @dataclass_json


### PR DESCRIPTION
…ting

Introduces a new configuration option, `metadata_write_url`, to control whether the media file URL is included in metadata. Updates logic to respect this setting.

- ✨ **Feature**: Adds `metadata_write_url` to enable/disable URL writing in metadata.
- 🔧 **Logic Update**: Adjusts URL handling to check the new setting before including it.
- 📝 **Documentation**: Updates help descriptions to explain the new option.

This change improves flexibility in metadata customization.